### PR TITLE
Fix typo/missing word in SEO field description.

### DIFF
--- a/app/src/pages/Page.php
+++ b/app/src/pages/Page.php
@@ -20,7 +20,7 @@ namespace {
 
             $fields->addFieldsToTab("Root.Main", [
                 TextField::create("SeoTitle")
-                    ->setDescription("For if you're wanting to some fancy flare to your page titles.")
+                    ->setDescription("For if you're wanting to add some fancy flare to your page titles.")
             ], "MenuTitle");
 
             return $fields;


### PR DESCRIPTION
This has been bugging me for a while - added the word 'add' to the SEO field description.